### PR TITLE
Set blackout status only when not already set

### DIFF
--- a/blackout_regex.py
+++ b/blackout_regex.py
@@ -55,7 +55,8 @@ class BlackoutRegex(PluginBase):
                             blackout.id,
                             alert.id,
                         )
-                        alert.set_status('blackout')
+                        if alert.status != 'blackout':
+                            alert.set_status('blackout')
                         return alert
             # If the blackout is no longer active, simply return
             # the alert as-is, without changing the status, but


### PR DESCRIPTION
I've noticed that otherwise it's going to set the status
everytime the alert is received.