### PR TITLE
Act on the pre_receive and cache Blackouts for 60 seconds

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ mock==4.0.1
 nose==1.3.7
 black==19.10b0
 pylama==7.7.1
+alerta==8.4.0


### PR DESCRIPTION
We currently act on the every alert in the `post_receive` which
evaluates the alert _after_ it has been correlated et al. While this is
an optimal approach from some perspectives, it introduces some confusion
and the alert risks to be thrown to other plugins before it's been acted
on (for example displayed in Slack).
To work around this unfortunate design choice, moving the code to be
executed in `pre_receive`; this has the major disadvantage that every
alert would request the Blackouts API endpoint - but caching the results
into a file would alleviate this.